### PR TITLE
2 tom targerts cannot be resolved

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2423,4 +2423,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9.0,<3.13"
-content-hash = "be8f30aad4989d105e8bfc9a10cebade30c4359440d8236263263a3a50948095"
+content-hash = "4094c97934ab619c331fbf835892876824e8a917ef5a9357b989b5e2b4fad02d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.9.0,<3.13"
 dependencies = [
-    "tomtoolkit (>=2.23.1,<3.0.0)"
+    "tomtoolkit (>=2.24.0,<3.0.0)"
 ]
 
 [tool.poetry]

--- a/tom_classifications/migrations/0001_initial.py
+++ b/tom_classifications/migrations/0001_initial.py
@@ -2,15 +2,17 @@
 
 from django.db import migrations, models
 import django.db.models.deletion
-
+from tom_targets.models import Target
 
 class Migration(migrations.Migration):
 
     initial = True
 
     dependencies = [
-        ('tom_targets', '0019_auto_20210811_0018'),
+        ('tom_targets', '0026_alter_basetarget_permissions'),
     ]
+
+    
 
     operations = [
         migrations.CreateModel(
@@ -22,7 +24,7 @@ class Migration(migrations.Migration):
                 ('classification', models.TextField(blank=True, default='')),
                 ('probability', models.FloatField(blank=True, null=True)),
                 ('mjd', models.FloatField(blank=True, null=True)),
-                ('target', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='tom_targets.target')),
+                ('target', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='tom_targets.basetarget')),
             ],
         ),
     ]


### PR DESCRIPTION
This seems to be a much simpler fix than I was originally anticipating. 
We can alter the offending migration directly. 

I tested this for many different situations including with model objects existing in the DB.
I think this should work as a valid solution for non-localized events as well, but will need to be tested.